### PR TITLE
feat/move-wall: 캐릭터 이동에 따른 wall 이동

### DIFF
--- a/src/pages/PizzaLegend/GameObject.ts
+++ b/src/pages/PizzaLegend/GameObject.ts
@@ -6,11 +6,17 @@ class GameObject {
   public y: number;
   public sprite: any;
   public direction: string;
+  private isMounted: boolean;
   constructor(config: any) {
+    this.isMounted = false;
     this.x = config.x || 0;
     this.y = config.y || 0;
     this.direction = config.direction || "down";
     this.sprite = new Sprite({ gameObject: this, src: config.src || Hero });
+  }
+  mount(map: any) {
+    this.isMounted = true;
+    map.addWall(this.x, this.y);
   }
 
   update(param: {}) {}

--- a/src/pages/PizzaLegend/Overworld.ts
+++ b/src/pages/PizzaLegend/Overworld.ts
@@ -60,6 +60,7 @@ class Overworld {
 
   init() {
     this.map = new OverworldMap(window.OverworldMaps.DemoRoom);
+    this.map.mountObjects();
     this.directionInput.init();
     this.startGameLoop();
     // const image = new Image();

--- a/src/pages/PizzaLegend/OverworldMap.ts
+++ b/src/pages/PizzaLegend/OverworldMap.ts
@@ -41,6 +41,27 @@ class OverworldMap {
     const { x, y } = utils.nextPosition(currentX, currentY, direction);
     return this.walls[`${x},${y}`] || false;
   }
+
+  mountObjects() {
+    Object.values(this.gameObjects).forEach((object) => {
+      // TODO: determine if this object should actually mount
+      // @ts-ignore
+      object.mount(this);
+    });
+  }
+
+  //gameObjects들에 대한 collision 반영을 위해
+  addWall(x: number, y: number) {
+    this.walls[`${x},${y}`] = true;
+  }
+  removeWall(x: number, y: number) {
+    delete this.walls[`${x},${y}`];
+  }
+  moveWall(wasX: number, wasY: number, direction: string) {
+    this.removeWall(wasX, wasY);
+    const { x, y } = utils.nextPosition(wasX, wasY, direction);
+    this.addWall(x, y);
+  }
 }
 
 window.OverworldMaps = {

--- a/src/pages/PizzaLegend/Person.ts
+++ b/src/pages/PizzaLegend/Person.ts
@@ -48,6 +48,8 @@ class Person extends GameObject {
         return;
       }
       //ready to walk
+      //wall이 움직이도록(움직이지 않으면 hero의 원래 위치에 wall이 있어서 거기로 못 감)
+      state.map.moveWall(this.x, this.y, this.direction);
       this.movingProgressRemaining = 16;
     }
   }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -3,8 +3,8 @@ import SimpleTest from "../pages/SimpleTest";
 import PizzaLegend from "../pages/PizzaLegend/PizzaLegend";
 
 const router = createBrowserRouter([
-  { path: "/", element: <SimpleTest /> },
-  { path: "/pizza-legend", element: <PizzaLegend /> },
+  { path: "/", element: <PizzaLegend /> },
+  { path: "/test", element: <SimpleTest /> },
 ]);
 
 export default router;


### PR DESCRIPTION
## feat/move-wall: 캐릭터 이동에 따른 wall 이동
기존에 hero가 있던 자리에 wall이 생기면서 hero가 원래 자리로는 이동할 수 없는 오류가 발생했습니다. 관련해서 move-wall이라는 메서드를 통해, 이동에 따라 wall을 옮겨주었습니다.